### PR TITLE
Create ticket

### DIFF
--- a/app/controllers/api/tickets_controller.rb
+++ b/app/controllers/api/tickets_controller.rb
@@ -21,10 +21,10 @@ class Api::TicketsController < ApplicationController
 
   def new_comment
     user = ZEN_CLIENT.users.search(:query => params[:user_email])
+    user_id = user.first.id
     ticket = ZEN_CLIENT.tickets.find(id: params[:id])
-    binding.pry
     #passing in the user id as the author_id should pull in the end-users info in the submitted comment according to https://support.zendesk.com/hc/en-us/community/posts/207597658-Adding-comments-to-existing-ticket-as-end-user
-    ticket.update(comment: {:body => comment_body, :author_id => user.id })
+    ticket.update(comment: {:body => params[:comment_body], :author_id => user_id})
     ticket.save
   end
 

--- a/app/controllers/api/tickets_controller.rb
+++ b/app/controllers/api/tickets_controller.rb
@@ -10,7 +10,7 @@ class Api::TicketsController < ApplicationController
     render json: serialize_comment(comment)
   end
 
-  def create(subject, comment_value, submitter)
+  def create(subject, comment_body, submitter)
     new_ticket = ZEN_CLIENT.tickets.create(:subject => subject, :comment => { :value => comment_body }, :via => { :source => { :from => { :name => submitter }}}, :requester => { :name => submitter })
   end
 

--- a/app/controllers/api/tickets_controller.rb
+++ b/app/controllers/api/tickets_controller.rb
@@ -11,7 +11,7 @@ class Api::TicketsController < ApplicationController
   end
 
   def create(subject, comment_value, submitter)
-    new_ticket = ZEN_CLIENT.tickets.create(:subject => subject, :comment => { :value => comment_body }, :submitter_id => submitter)
+    new_ticket = ZEN_CLIENT.tickets.create(:subject => subject, :comment => { :value => comment_body }, :via => { :source => { :from => { :name => submitter }}}, :requester => { :name => submitter })
   end
 
   private

--- a/app/controllers/api/tickets_controller.rb
+++ b/app/controllers/api/tickets_controller.rb
@@ -14,6 +14,12 @@ class Api::TicketsController < ApplicationController
     new_ticket = ZEN_CLIENT.tickets.create(:subject => subject, :comment => { :value => comment_body }, :via => { :source => { :from => { :name => submitter }}}, :requester => { :name => submitter })
   end
 
+  def create_comment
+    ticket = ZEN_CLIENT.tickets.find(id: params[:id])
+    ticket.update(comment: {:body => body, :via => { :source => { :from => { :name => submitter }}}, :requester => { :name => submitter }})
+    ticket.save
+  end
+
   private
     def serialize_tickets(tickets)
       ticket_array = []

--- a/app/controllers/api/tickets_controller.rb
+++ b/app/controllers/api/tickets_controller.rb
@@ -15,8 +15,9 @@ class Api::TicketsController < ApplicationController
   end
 
   def create_comment
+    user = ZEN_CLIENT.users.search(:query => user_email)
     ticket = ZEN_CLIENT.tickets.find(id: params[:id])
-    ticket.update(comment: {:body => body, :via => { :source => { :from => { :name => submitter }}}, :requester => { :name => submitter }})
+    ticket.update(comment: {:body => "body", :author_id => user.id })
     ticket.save
   end
 

--- a/app/controllers/api/tickets_controller.rb
+++ b/app/controllers/api/tickets_controller.rb
@@ -10,14 +10,21 @@ class Api::TicketsController < ApplicationController
     render json: serialize_comment(comment)
   end
 
-  def create(subject, comment_body, submitter)
-    new_ticket = ZEN_CLIENT.tickets.create(:subject => subject, :comment => { :value => comment_body }, :via => { :source => { :from => { :name => submitter }}}, :requester => { :name => submitter })
+  def create
+    new_ticket = ZEN_CLIENT.tickets.create(
+      :subject => params[:subject],
+      :comment => { :value => params[:comment_body] },
+      :via => { :source => { :from => { :name => params[:submitter] }}},
+      :requester => { :name => params[:submitter] }
+    )
   end
 
-  def create_comment
-    user = ZEN_CLIENT.users.search(:query => user_email)
+  def new_comment
+    user = ZEN_CLIENT.users.search(:query => params[:user_email])
     ticket = ZEN_CLIENT.tickets.find(id: params[:id])
-    ticket.update(comment: {:body => "body", :author_id => user.id })
+    binding.pry
+    #passing in the user id as the author_id should pull in the end-users info in the submitted comment according to https://support.zendesk.com/hc/en-us/community/posts/207597658-Adding-comments-to-existing-ticket-as-end-user
+    ticket.update(comment: {:body => comment_body, :author_id => user.id })
     ticket.save
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   namespace :api, defaults: { format: :json } do
      resources :tickets
+     match 'tickets/new_comment' => 'tickets#new_comment', via: :post
   end
 end


### PR DESCRIPTION
Hey Ben, I was able complete setting up the `create` method which creates a brand new ticket. What I'm having trouble with now is creating a comment (response) within an already existing ticket. Here's how I would imagine it happening:

```ruby
ZEN_CLIENT.tickets.find(id: 4).comments.create(:comment => {:value => "Zach is sending a comment"}, :requester => {:name => "Zach"})
```
So, 
1. The request finds ticket with the id of 4
2. Then pulls in the comments object and calls the create method
3. Then passes in the info

However, when approaching it this way, I get the following error:

`NoMethodError: undefined method "create" for ZendeskAPI::Ticket::Comment`

I've also tried it this way:

```ruby
ZEN_CLIENT.tickets.find(id: 4).create(:comment => {:value => "Zach is sending a comment"}, :requester => {:name => "Zach"} )
```
Which removes the comment object. But this returns `nil`. 

I've been looking through the Client docs but not having any luck with details on how to create a comment. Here's the ZD API doc which details how to create comments, but not within the Ruby Client: https://developer.zendesk.com/rest_api/docs/core/ticket_comments